### PR TITLE
Upgrade slick-migration-api to 0.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           POSTGRES_USER: circleci
           POSTGRES_DB: circle_test
     environment:
-      SBT_VERSION: 1.3.7
+      SBT_VERSION: 1.10.3
     steps:
       - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
       - run:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val repoKind = SettingKey[String]("repo-kind",
   "Maven repository kind (\"snapshots\" or \"releases\")")
 
-lazy val slickVersion = "3.3.3"
+lazy val slickVersion = "3.5.2"
 
 lazy val scala212 = "2.12.11"
 lazy val scala213 = "2.13.8"
@@ -16,7 +16,7 @@ lazy val coreDependencies = libraryDependencies ++= List(
 lazy val slickDependencies = List(
   "com.typesafe.slick" %% "slick" % slickVersion,
   "com.typesafe.slick" %% "slick-codegen" % slickVersion,
-  "io.github.nafg" %% "slick-migration-api" % "0.8.0",
+  "io.github.nafg" %% "slick-migration-api" % "0.10.0",
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1"
 )
 
@@ -42,28 +42,28 @@ lazy val commonSettings = Seq(
   scalaVersion := scala213,
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
-  resolvers += Resolver.jcenterRepo,
+  resolvers ++= Seq(Resolver.jcenterRepo, "asana-oss-cache" at "https://asana-oss-cache.s3.us-east-1.amazonaws.com/maven/release/"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   repoKind := { if (version.value.trim.endsWith("SNAPSHOT")) "snapshots"
-                else "releases" },
+  else "releases" },
   publishTo := { repoKind.value match {
     case "snapshots" => Some("snapshots" at
-        "https://oss.sonatype.org/content/repositories/snapshots")
+      "https://oss.sonatype.org/content/repositories/snapshots")
     case "releases" =>  Some("releases"  at
-        "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+      "https://oss.sonatype.org/service/local/staging/deploy/maven2")
   }},
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
   pomExtra := (
     <scm>
       <url>git@github.com:lastland/scala-forklift.git</url>
       <connection>scm:git:git@github.com:lastland/scala-forklift.git</connection>
-      </scm>
+    </scm>
       <developers>
-      <developer>
-      <id>lastland</id>
-      <name>Yao Li</name>
-      </developer>
+        <developer>
+          <id>lastland</id>
+          <name>Yao Li</name>
+        </developer>
       </developers>))
 
 // Derby is running is secured mode since version 10.12.1.1, so security manager must be disabled for tests  
@@ -80,16 +80,16 @@ lazy val root = Project(
 lazy val coreProject = Project(
   "scala-forklift-core", file("core")).settings(
   commonSettings:_*).settings {Seq(
-    crossScalaVersions := supportedScalaVersions,
-    coreDependencies
-  )}
+  crossScalaVersions := supportedScalaVersions,
+  coreDependencies
+)}
 
 lazy val slickMigrationProject = Project(
   "scala-forklift-slick", file("migrations/slick")).dependsOn(
   coreProject).settings(commonSettings:_*).settings { Seq(
-    crossScalaVersions := supportedScalaVersions,
-    libraryDependencies ++= slickDependenciesWithTests
-  )} 
+  crossScalaVersions := supportedScalaVersions,
+  libraryDependencies ++= slickDependenciesWithTests
+)}
 
 lazy val plainMigrationProject = Project(
   "scala-forklift-plain", file("migrations/plain")).dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val repoKind = SettingKey[String]("repo-kind",
   "Maven repository kind (\"snapshots\" or \"releases\")")
 
-lazy val slickVersion = "3.5.2"
+lazy val slickVersion = "3.4.1"
 
 lazy val scala212 = "2.12.11"
 lazy val scala213 = "2.13.8"
@@ -21,7 +21,7 @@ lazy val slickDependencies = List(
 )
 
 lazy val slickDependenciesWithTests = slickDependencies ++ List(
-  "org.scalatest" %% "scalatest" % "3.2.12",
+  "org.scalatest" %% "scalatest" % "3.0.9",
   "com.lihaoyi" %% "ammonite-ops" % "2.4.1",
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,

--- a/migrations/slick/src/main/scala/Codegen.scala
+++ b/migrations/slick/src/main/scala/Codegen.scala
@@ -95,7 +95,7 @@ object Glob{
         case Some(lists) =>
           val filtered = lists.filter{ c =>  filter(c) }.toList
           val childDirs = lists.filter{ c => c.isDirectory && !c.getName.startsWith(".") }
-          return ( (acc ::: filtered) /: childDirs){ (a, dir) => recursive(dir, a)}
+          return childDirs.foldLeft(acc ::: filtered){ (a, dir) => recursive(dir, a)}
       }
     dirs.flatMap{ d => recursive(new File(d), Nil)}
   }

--- a/migrations/slick/src/main/scala/Commands.scala
+++ b/migrations/slick/src/main/scala/Commands.scala
@@ -118,16 +118,16 @@ trait SlickMigrationCommands
     notYetAppliedMigrations.map { migration =>
       migration match {
         case m: SqlMigrationInterface[_] =>
-          println(migration.id + " SqlMigration:")
+          println(s"${migration.id} SqlMigration:")
           println("\t" + m.queries.map(_.getDumpInfo.mainInfo).mkString("\n\t"))
         case m: SqlResourceMigrationInterface[_] =>
-          println(migration.id + " SqlResourceMigration:")
+          println(s"${migration.id} SqlResourceMigration:")
           println(m.sqlQueries)
         case m: DBIOMigration[_] =>
-          println(migration.id + " DBIOMigration:")
+          println(s"${migration.id} DBIOMigration:")
           println("\t" + m.code)
         case m: APIMigration[_] =>
-          println(migration.id + " APIMigration:")
+          println(s"${migration.id} APIMigration:")
           println("\t" + m.migration.sql)
       }
       println("")

--- a/migrations/slick/src/main/scala/SlickMigrationManager.scala
+++ b/migrations/slick/src/main/scala/SlickMigrationManager.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import slick.backend.DatabaseConfig
+import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import slick.jdbc.meta.MTable
 import com.liyaos.forklift.core.Migration

--- a/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
+++ b/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
@@ -79,7 +79,7 @@ trait SQLiteConfigFile extends ConfigFile with Tables {
 trait MySQLConfigFile extends ConfigFile with Tables {
   val user = "root"
   val driver = "slick.jdbc.MySQLProfile$"
-  val dbDriver = "com.mysql.jdbc.Driver"
+  val dbDriver = "com.mysql.cj.jdbc.Driver"
   val dbUrl = s"jdbc:mysql://localhost/circle_test?useSSL=false"
 
   val profile = slick.jdbc.MySQLProfile

--- a/migrations/slick/src/test/scala/UnitTests/SlickMigrationManagerTests.scala
+++ b/migrations/slick/src/test/scala/UnitTests/SlickMigrationManagerTests.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import slick.jdbc.meta.MTable
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 
 trait MigrationTests extends FlatSpec with PrivateMethodTester {
   this: ConfigFile with Tables =>


### PR DESCRIPTION
Version 0.3.2 of scala-forklift requires `slick-migration-api` version 0.7.0 but in the maven repository only `>=0.8.0` are available, this therefore needs to be updates.