### PR TITLE
Upgrade slick-migration-api to 0.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           MYSQL_DATABASE: circle_test
           MYSQL_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-      - image: cimg/postgres:9.6.9
+      - image: cimg/postgres:9.6.23
         environment:
           POSTGRES_USER: circleci
           POSTGRES_DB: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,22 @@ jobs:
     steps:
       - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
       - run:
-          name: Get sbt binary
+          name: Install python dependencies
           command: |
                     apt update && apt install -y curl
+                    sudo apt-get update
+                    sudo apt-get install -y python3-pip git
+                    pip install awscli
+                    sudo apt-get clean && sudo apt-get autoclean
+      - run:
+          name: Get sbt binary
+          command: |
                     cd ..
                     curl -L -o sbt-$SBT_VERSION.tgz https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz
                     tar -xvf sbt-$SBT_VERSION.tgz
                     cd sbt/bin
                     sudo chmod +x sbt
                     export PATH=$PATH:$(pwd)
-                    sudo apt-get update
-                    sudo apt-get install -y python3-pip git
-                    pip install awscli
-                    sudo apt-get clean && sudo apt-get autoclean
                     cd ~/scala-forklift
       - run: ls ~/scala-forklift
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           name: Get sbt binary
           command: |
                     apt update && apt install -y curl
+                    cd ..
                     curl -L -o sbt-$SBT_VERSION.tgz https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz
                     tar -xvf sbt-$SBT_VERSION.tgz
                     cd sbt/bin
@@ -30,6 +31,7 @@ jobs:
                     sudo apt-get install -y python3-pip git
                     pip install awscli
                     sudo apt-get clean && sudo apt-get autoclean
+                    cd scala-forklift/
       - run: ls ~/scala-forklift
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
                     pip3 install awscli
                     sudo apt-get clean && sudo apt-get autoclean
       - run:
-          name: Get sbt binary
+          name: Setup sbt
           command: |
                     cd ..
                     curl -L -o sbt-$SBT_VERSION.tgz https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz
@@ -35,7 +35,6 @@ jobs:
                     sudo chmod +x sbt
                     export PATH=$PATH:$(pwd)
                     cd ~/scala-forklift
-      - run: ls ~/scala-forklift
       - checkout
       - restore_cache:
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
                     sudo chmod +x sbt
                     export PATH=$PATH:$(pwd)
                     sudo apt-get update
-                    sudo apt-get install -y python-pip git
+                    sudo apt-get install -y python3-pip git
                     pip install awscli
                     sudo apt-get clean && sudo apt-get autoclean
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,11 @@ jobs:
             sbt +test:compile
             sbt +publishLocal
       - run:
+          name: Test scala-forklift scala 2.12
+          command: sbt '++ 2.12.11; test:test'
+          environment:
+            JAVA_OPTS: "-Xms256m -Xmx512m"
+      - run:
           name: Test scala-forklift scala 2.13
           command: sbt '++ 2.13.1; test:test'
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
                     sudo apt-get install -y python3-pip git
                     pip install awscli
                     sudo apt-get clean && sudo apt-get autoclean
+      - run: ls ~/scala-forklift
       - checkout
       - restore_cache:
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,11 @@ jobs:
           name: Get sbt binary
           command: |
                     apt update && apt install -y curl
-                    curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
-                    sudo dpkg -i sbt-$SBT_VERSION.deb
-                    rm sbt-$SBT_VERSION.deb
+                    curl -L -o sbt-$SBT_VERSION.tgz https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz
+                    tar -xvf sbt-$SBT_VERSION.tgz
+                    cd sbt/bin
+                    sudo chmod +x sbt
+                    ./sbt
                     sudo apt-get update
                     sudo apt-get install -y sbt python-pip git
                     pip install awscli
@@ -33,7 +35,7 @@ jobs:
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: sbt-cache
       - run:
-          name: Crossompile scala-forklift
+          name: Crosscompile scala-forklift
           command: sbt +compile
       - run:
           name: Compile tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
                     sudo apt-get install -y python3-pip git
                     pip install awscli
                     sudo apt-get clean && sudo apt-get autoclean
-                    cd scala-forklift/
+                    cd ~/scala-forklift
       - run: ls ~/scala-forklift
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
       - image: cimg/mysql:8.0
         environment:
           MYSQL_DATABASE: circle_test
-          MYSQL_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: true
       - image: cimg/postgres:9.6.23
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/scala-forklift
     docker:
-      - image: circleci/openjdk:8
+      - image: circleci/openjdk:11
       - image: circleci/mysql:5.7.29
         environment:
           MYSQL_DATABASE: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/scala-forklift
     docker:
-      - image: cimg/openjdk:11
+      - image: cimg/openjdk:11.0.25
       - image: cimg/mysql:8.0
         environment:
           MYSQL_DATABASE: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ jobs:
   build:
     working_directory: ~/scala-forklift
     docker:
-      - image: circleci/openjdk:11
-      - image: circleci/mysql:5.7.29
+      - image: cimg/openjdk:11
+      - image: cimg/mysql:8.0
         environment:
           MYSQL_DATABASE: circle_test
           MYSQL_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-      - image: circleci/postgres:9.6.9
+      - image: cimg/postgres:9.6.9
         environment:
           POSTGRES_USER: circleci
           POSTGRES_DB: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           POSTGRES_USER: circleci
           POSTGRES_DB: circle_test
     environment:
-      SBT_VERSION: 1.3.7
+      SBT_VERSION: 1.10.3
     steps:
       - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             JAVA_OPTS: "-Xms256m -Xmx512m"
       - run:
           name: Test scala-forklift scala 2.13
-          command: sbt '++ 2.13.1; test:test'
+          command: sbt '++ 2.13.14; test:test'
           environment:
             JAVA_OPTS: "-Xms256m -Xmx512m"
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,6 @@ jobs:
             sbt +test:compile
             sbt +publishLocal
       - run:
-          name: Test scala-forklift scala 2.12
-          command: sbt '++ 2.12.11; test:test'
-          environment:
-            JAVA_OPTS: "-Xms256m -Xmx512m"
-      - run:
           name: Test scala-forklift scala 2.13
           command: sbt '++ 2.13.1; test:test'
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
                     apt update && apt install -y curl
                     sudo apt-get update
                     sudo apt-get install -y python3-pip git
-                    pip install awscli
+                    pip3 install awscli
                     sudo apt-get clean && sudo apt-get autoclean
       - run:
           name: Get sbt binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ jobs:
                     tar -xvf sbt-$SBT_VERSION.tgz
                     cd sbt/bin
                     sudo chmod +x sbt
-                    ./sbt
+                    export PATH=$PATH:$(pwd)
                     sudo apt-get update
-                    sudo apt-get install -y sbt python-pip git
+                    sudo apt-get install -y python-pip git
                     pip install awscli
                     sudo apt-get clean && sudo apt-get autoclean
       - checkout

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "mysql" % "mysql-connector-java" % "8.0.30",
   "org.postgresql" % "postgresql" % "42.5.0",
   "org.hsqldb" % "hsqldb" % "2.7.0",
-  "org.apache.derby" % "derby" % "10.15.2.0",
+  "org.apache.derby" % "derby" % "10.17.1.0",
   "ch.qos.logback" % "logback-classic" % "1.2.11"
 ).map(_ % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,8 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "com.lihaoyi" %% "ammonite-ops" % "2.4.1",
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
-  "com.h2database" % "h2" % "1.4.200",
-  "com.zaxxer" % "HikariCP" % "6.2.1",
+  "com.h2database" % "h2" % "2.7.2",
+  "com.zaxxer" % "HikariCP" % "5.1.0",
   "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
   "mysql" % "mysql-connector-java" % "8.0.33",
   "org.postgresql" % "postgresql" % "42.5.0",

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val supportedScalaVersions = List(scala212, scala213)
 
 lazy val coreDependencies = libraryDependencies ++= List(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "com.typesafe" % "config" % "1.4.2",
+  "com.typesafe" % "config" % "1.4.3",
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.0.1.201506240215-r"
 )
 
@@ -26,7 +26,8 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
   "com.h2database" % "h2" % "2.1.214",
-  "org.xerial" % "sqlite-jdbc" % "3.8.11.2",// 3.30.1 crashes SQLiteCommandTests
+  "com.zaxxer" % "HikariCP" % "6.2.1",
+  "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
   "mysql" % "mysql-connector-java" % "8.0.30",
   "org.postgresql" % "postgresql" % "42.5.0",
   "org.hsqldb" % "hsqldb" % "2.7.0",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val commonSettings = Seq(
   scalacOptions += "-feature",
   resolvers ++= Seq(Resolver.jcenterRepo, "asana-oss-cache" at "https://asana-oss-cache.s3.us-east-1.amazonaws.com/maven/release/"),
   publishMavenStyle := true,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   repoKind := { if (version.value.trim.endsWith("SNAPSHOT")) "snapshots"
   else "releases" },
   publishTo := { repoKind.value match {

--- a/build.sbt
+++ b/build.sbt
@@ -25,13 +25,13 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "com.lihaoyi" %% "ammonite-ops" % "2.4.1",
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
-  "com.h2database" % "h2" % "2.3.232",
+  "com.h2database" % "h2" % "1.4.200",
   "com.zaxxer" % "HikariCP" % "6.2.1",
   "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
   "mysql" % "mysql-connector-java" % "8.0.33",
   "org.postgresql" % "postgresql" % "42.5.0",
-  "org.hsqldb" % "hsqldb" % "2.7.0",
-  "org.apache.derby" % "derby" % "10.17.1.0",
+  "org.hsqldb" % "hsqldb" % "2.5.2",
+  "org.apache.derby" % "derby" % "10.14.2.0",
   "ch.qos.logback" % "logback-classic" % "1.2.11"
 ).map(_ % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "com.h2database" % "h2" % "2.1.214",
   "com.zaxxer" % "HikariCP" % "5.1.0",
   "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
-  "mysql" % "mysql-connector-java" % "8.0.30",
+  "com.mysql" % "mysql-connector-j" % "8.0.33",
   "org.postgresql" % "postgresql" % "42.5.0",
   "org.hsqldb" % "hsqldb" % "2.7.0",
   "org.apache.derby" % "derby" % "10.17.1.0",

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "com.h2database" % "h2" % "2.3.232",
   "com.zaxxer" % "HikariCP" % "6.2.1",
   "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
-  "mysql" % "mysql-connector-java" % "8.0.30",
+  "mysql" % "mysql-connector-java" % "8.0.33",
   "org.postgresql" % "postgresql" % "42.5.0",
   "org.hsqldb" % "hsqldb" % "2.7.0",
   "org.apache.derby" % "derby" % "10.17.1.0",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val repoKind = SettingKey[String]("repo-kind",
   "Maven repository kind (\"snapshots\" or \"releases\")")
 
-lazy val slickVersion = "3.4.1"
+lazy val slickVersion = "3.5.2"
 
 lazy val scala212 = "2.12.11"
 lazy val scala213 = "2.13.8"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val repoKind = SettingKey[String]("repo-kind",
   "Maven repository kind (\"snapshots\" or \"releases\")")
 
-lazy val slickVersion = "3.3.3"
+lazy val slickVersion = "3.5.2"
 
 lazy val scala212 = "2.12.11"
 lazy val scala213 = "2.13.8"
@@ -16,7 +16,7 @@ lazy val coreDependencies = libraryDependencies ++= List(
 lazy val slickDependencies = List(
   "com.typesafe.slick" %% "slick" % slickVersion,
   "com.typesafe.slick" %% "slick-codegen" % slickVersion,
-  "io.github.nafg" %% "slick-migration-api" % "0.8.0",
+  "io.github.nafg" %% "slick-migration-api" % "0.10.0",
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1"
 )
 
@@ -42,28 +42,28 @@ lazy val commonSettings = Seq(
   scalaVersion := scala213,
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
-  resolvers += Resolver.jcenterRepo,
+  resolvers ++= Seq(Resolver.jcenterRepo, "asana-oss-cache" at "https://asana-oss-cache.s3.us-east-1.amazonaws.com/maven/release/"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   repoKind := { if (version.value.trim.endsWith("SNAPSHOT")) "snapshots"
-                else "releases" },
+  else "releases" },
   publishTo := { repoKind.value match {
     case "snapshots" => Some("snapshots" at
-        "https://oss.sonatype.org/content/repositories/snapshots")
+      "https://oss.sonatype.org/content/repositories/snapshots")
     case "releases" =>  Some("releases"  at
-        "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+      "https://oss.sonatype.org/service/local/staging/deploy/maven2")
   }},
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
   pomExtra := (
     <scm>
       <url>git@github.com:lastland/scala-forklift.git</url>
       <connection>scm:git:git@github.com:lastland/scala-forklift.git</connection>
-      </scm>
+    </scm>
       <developers>
-      <developer>
-      <id>lastland</id>
-      <name>Yao Li</name>
-      </developer>
+        <developer>
+          <id>lastland</id>
+          <name>Yao Li</name>
+        </developer>
       </developers>))
 
 // Derby is running is secured mode since version 10.12.1.1, so security manager must be disabled for tests  
@@ -80,16 +80,16 @@ lazy val root = Project(
 lazy val coreProject = Project(
   "scala-forklift-core", file("core")).settings(
   commonSettings:_*).settings {Seq(
-    crossScalaVersions := supportedScalaVersions,
-    coreDependencies
-  )}
+  crossScalaVersions := supportedScalaVersions,
+  coreDependencies
+)}
 
 lazy val slickMigrationProject = Project(
   "scala-forklift-slick", file("migrations/slick")).dependsOn(
   coreProject).settings(commonSettings:_*).settings { Seq(
-    crossScalaVersions := supportedScalaVersions,
-    libraryDependencies ++= slickDependenciesWithTests
-  )} 
+  crossScalaVersions := supportedScalaVersions,
+  libraryDependencies ++= slickDependenciesWithTests
+)}
 
 lazy val plainMigrationProject = Project(
   "scala-forklift-plain", file("migrations/plain")).dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -25,13 +25,13 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "com.lihaoyi" %% "ammonite-ops" % "2.4.1",
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
-  "com.h2database" % "h2" % "2.7.2",
+  "com.h2database" % "h2" % "2.1.214",
   "com.zaxxer" % "HikariCP" % "5.1.0",
   "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
-  "mysql" % "mysql-connector-java" % "8.0.33",
+  "mysql" % "mysql-connector-java" % "8.0.30",
   "org.postgresql" % "postgresql" % "42.5.0",
-  "org.hsqldb" % "hsqldb" % "2.5.2",
-  "org.apache.derby" % "derby" % "10.14.2.0",
+  "org.hsqldb" % "hsqldb" % "2.7.0",
+  "org.apache.derby" % "derby" % "10.17.1.0",
   "ch.qos.logback" % "logback-classic" % "1.2.11"
 ).map(_ % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "com.lihaoyi" %% "ammonite-ops" % "2.4.1",
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
-  "com.h2database" % "h2" % "2.1.214",
+  "com.h2database" % "h2" % "2.3.232",
   "com.zaxxer" % "HikariCP" % "6.2.1",
   "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
   "mysql" % "mysql-connector-java" % "8.0.30",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val repoKind = SettingKey[String]("repo-kind",
   "Maven repository kind (\"snapshots\" or \"releases\")")
 
-lazy val slickVersion = "3.5.2"
+lazy val slickVersion = "3.4.1"
 
 lazy val scala212 = "2.12.11"
 lazy val scala213 = "2.13.8"
@@ -21,7 +21,7 @@ lazy val slickDependencies = List(
 )
 
 lazy val slickDependenciesWithTests = slickDependencies ++ List(
-  "org.scalatest" %% "scalatest" % "3.2.12",
+  "org.scalatest" %% "scalatest" % "3.0.9",
   "com.lihaoyi" %% "ammonite-ops" % "2.4.1",
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val supportedScalaVersions = List(scala212, scala213)
 lazy val coreDependencies = libraryDependencies ++= List(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   "com.typesafe" % "config" % "1.4.3",
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.0.1.201506240215-r"
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "7.0.0.202409031743-r"
 )
 
 lazy val slickDependencies = List(
@@ -26,7 +26,6 @@ lazy val slickDependenciesWithTests = slickDependencies ++ List(
   "commons-io" % "commons-io" % "2.6",
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
   "com.h2database" % "h2" % "2.1.214",
-  "com.zaxxer" % "HikariCP" % "5.1.0",
   "org.xerial" % "sqlite-jdbc" % "3.47.1.0",// 3.30.1 crashes SQLiteCommandTests
   "com.mysql" % "mysql-connector-j" % "8.0.33",
   "org.postgresql" % "postgresql" % "42.5.0",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val repoKind = SettingKey[String]("repo-kind",
 lazy val slickVersion = "3.5.2"
 
 lazy val scala212 = "2.12.11"
-lazy val scala213 = "2.13.8"
+lazy val scala213 = "2.13.14"
 lazy val supportedScalaVersions = List(scala212, scala213)
 
 lazy val coreDependencies = libraryDependencies ++= List(

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     JAVA_OPTS: "-Xms256m -Xmx512m"
   java:
-    version: oraclejdk8
+    version: oraclejdk11
   python:
     version: 2.7.9
 dependencies:

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -20,7 +20,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val loggingDependencies = List(
-  "org.slf4j" % "slf4j-nop" % "1.6.4" // <- disables logging
+  "org.slf4j" % "slf4j-nop" % "2.0.16" // <- disables logging
 )
 
 lazy val slickDependencies = List(

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -15,7 +15,7 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.13.1",
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
-  resolvers += Resolver.Resolver.sonatypeOssRepos("snapshots"),
+  resolvers += Resolver.sonatypeOssRepos("snapshots"),
   resolvers += Resolver.jcenterRepo,
 
 )

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -15,9 +15,8 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.13.1",
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
-  resolvers ++= Resolver.sonatypeOssRepos("snapshots",
+  resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
   resolvers ++= Seq(Resolver.jcenterRepo, "asana-oss-cache" at "https://asana-oss-cache.s3.us-east-1.amazonaws.com/maven/release/"),
-
 )
 
 lazy val loggingDependencies = List(

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -16,7 +16,7 @@ lazy val commonSettings = Seq(
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
   resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
-  resolvers ++= Seq(Resolver.jcenterRepo, "asana-oss-cache" at "https://asana-oss-cache.s3.us-east-1.amazonaws.com/maven/release/"),
+  resolvers += Resolver.jcenterRepo,
 )
 
 lazy val loggingDependencies = List(

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -15,7 +15,7 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.13.1",
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
-  resolvers += Resolver.sonatypeRepos("snapshots"),
+  resolvers ++= Resolver.sonatypeOssRepos("snapshots",
   resolvers ++= Seq(Resolver.jcenterRepo, "asana-oss-cache" at "https://asana-oss-cache.s3.us-east-1.amazonaws.com/maven/release/"),
 
 )

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -5,9 +5,9 @@ addCommandAlias("mgm", "migration_manager/run")
 addCommandAlias("mg", "migrations/run")
 
 
-lazy val slickVersion = "3.3.2"
+lazy val slickVersion = "3.5.2"
 
-lazy val forkliftVersion = "0.3.2-SNAPSHOT"
+lazy val forkliftVersion = "0.3.2"
 
 lazy val commonSettings = Seq(
   organization := "com.liyaos",
@@ -15,7 +15,7 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.13.1",
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
-  resolvers += Resolver.sonatypeRepo("snapshots"),
+  resolvers += Resolver.Resolver.sonatypeOssRepos("snapshots"),
   resolvers += Resolver.jcenterRepo,
 
 )
@@ -29,8 +29,8 @@ lazy val slickDependencies = List(
 )
 
 lazy val dbDependencies = List(
-  "com.typesafe.slick" %% "slick-hikaricp" % slickVersion
-  ,"com.h2database" % "h2" % "1.4.200"
+  "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
+  "com.h2database" % "h2" % "2.3.232"
 )
 
 lazy val forkliftDependencies = List(

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -15,8 +15,8 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.13.1",
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
-  resolvers += Resolver.sonatypeOssRepos("snapshots"),
-  resolvers += Resolver.jcenterRepo,
+  resolvers += Resolver.sonatypeRepos("snapshots"),
+  resolvers ++= Seq(Resolver.jcenterRepo, "asana-oss-cache" at "https://asana-oss-cache.s3.us-east-1.amazonaws.com/maven/release/"),
 
 )
 

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -7,12 +7,12 @@ addCommandAlias("mg", "migrations/run")
 
 lazy val slickVersion = "3.5.2"
 
-lazy val forkliftVersion = "0.3.2"
+lazy val forkliftVersion = "0.3.3-SNAPSHOT"
 
 lazy val commonSettings = Seq(
   organization := "com.liyaos",
   version := "2.0",
-  scalaVersion := "2.13.1",
+  scalaVersion := "2.13.14",
   scalacOptions += "-deprecation",
   scalacOptions += "-feature",
   resolvers ++= Resolver.sonatypeOssRepos("snapshots"),

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.10.3

--- a/migrations/slick/build.sbt
+++ b/migrations/slick/build.sbt
@@ -1,3 +1,3 @@
 name := "scala-forklift-slick"
 
-parallelExecution in Test := false
+Test / parallelExecution := false

--- a/migrations/slick/src/main/scala/Codegen.scala
+++ b/migrations/slick/src/main/scala/Codegen.scala
@@ -95,7 +95,7 @@ object Glob{
         case Some(lists) =>
           val filtered = lists.filter{ c =>  filter(c) }.toList
           val childDirs = lists.filter{ c => c.isDirectory && !c.getName.startsWith(".") }
-          return ( (acc ::: filtered) /: childDirs){ (a, dir) => recursive(dir, a)}
+          return childDirs.foldLeft(acc ::: filtered){ (a, dir) => recursive(dir, a)}
       }
     dirs.flatMap{ d => recursive(new File(d), Nil)}
   }

--- a/migrations/slick/src/main/scala/Commands.scala
+++ b/migrations/slick/src/main/scala/Commands.scala
@@ -118,16 +118,16 @@ trait SlickMigrationCommands
     notYetAppliedMigrations.map { migration =>
       migration match {
         case m: SqlMigrationInterface[_] =>
-          println(migration.id + " SqlMigration:")
+          println(s"${migration.id} SqlMigration:")
           println("\t" + m.queries.map(_.getDumpInfo.mainInfo).mkString("\n\t"))
         case m: SqlResourceMigrationInterface[_] =>
-          println(migration.id + " SqlResourceMigration:")
+          println(s"${migration.id} SqlResourceMigration:")
           println(m.sqlQueries)
         case m: DBIOMigration[_] =>
-          println(migration.id + " DBIOMigration:")
+          println(s"${migration.id} DBIOMigration:")
           println("\t" + m.code)
         case m: APIMigration[_] =>
-          println(migration.id + " APIMigration:")
+          println(s"${migration.id} APIMigration:")
           println("\t" + m.migration.sql)
       }
       println("")

--- a/migrations/slick/src/main/scala/SlickMigrationManager.scala
+++ b/migrations/slick/src/main/scala/SlickMigrationManager.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import slick.backend.DatabaseConfig
+import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import slick.jdbc.meta.MTable
 import com.liyaos.forklift.core.Migration

--- a/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
+++ b/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
@@ -14,8 +14,8 @@ class CommandsTest extends FlatSpec
 
   implicit def pathToString(path: Path) = path.toString
 
-  val unhandled = testDir/'migrations/'src_migrations/'main/'scala
-  val handled = testDir/'migrations/'src/'main/'scala/'migrations
+  val unhandled = testDir/Symbol("migrations/src_migrations/main/scala")
+  val handled = testDir/Symbol("migrations/src/main/scala/migrations")
 
   before {
     dir.setup()

--- a/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
+++ b/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
@@ -12,7 +12,7 @@ class CommandsTest extends FlatSpec
   val dir = TestDir.createTestDir(wd)
   val testDir = dir.testPath
 
-  implicit def pathToString(path: Path) = path.toString
+  implicit def pathToString(path: Path): String = path.toString
 
   val unhandled = testDir/Symbol("migrations/src_migrations/main/scala")
   val handled = testDir/Symbol("migrations/src/main/scala/migrations")
@@ -63,7 +63,7 @@ class CommandsTest extends FlatSpec
     %sbt("mg init", "mg update", "mg apply")
     %sbt("mg codegen", "mg update", "mg apply")
     val file = new File(
-      testDir/'generated_code/'src/'main/'scala/'datamodel/'v1/'schema/"schema.scala")
+      testDir/Symbol("generated_code/src/main/scala/datamodel/v1/schema/schema.scala")
     assert(file.exists)
   }
 

--- a/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
+++ b/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
@@ -14,8 +14,8 @@ class CommandsTest extends FlatSpec
 
   implicit def pathToString(path: Path): String = path.toString
 
-  val unhandled = testDir/Symbol("migrations/src_migrations/main/scala")
-  val handled = testDir/Symbol("migrations/src/main/scala/migrations")
+  val unhandled = testDir/Symbol("migrations")/Symbol("src_migrations")/Symbol("main")/Symbol("scala")
+  val handled = testDir/Symbol("migrations")/Symbol("src")/Symbol("main")/Symbol("scala")/Symbol("migrations")
 
   before {
     dir.setup()
@@ -63,7 +63,7 @@ class CommandsTest extends FlatSpec
     %sbt("mg init", "mg update", "mg apply")
     %sbt("mg codegen", "mg update", "mg apply")
     val file = new File(
-      testDir/Symbol("generated_code/src/main/scala/datamodel/v1/schema/schema.scala"))
+      testDir/Symbol("generated_code")/Symbol("src")/Symbol("main")/Symbol("scala")/Symbol("datamodel")/Symbol("v1")/Symbol("schema")/Symbol("schema.scala"))
     assert(file.exists)
   }
 

--- a/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
+++ b/migrations/slick/src/test/scala/SubProjectsTests/CommandsTests.scala
@@ -63,7 +63,7 @@ class CommandsTest extends FlatSpec
     %sbt("mg init", "mg update", "mg apply")
     %sbt("mg codegen", "mg update", "mg apply")
     val file = new File(
-      testDir/Symbol("generated_code/src/main/scala/datamodel/v1/schema/schema.scala")
+      testDir/Symbol("generated_code/src/main/scala/datamodel/v1/schema/schema.scala"))
     assert(file.exists)
   }
 

--- a/migrations/slick/src/test/scala/SubProjectsTests/MigrationDatabaseTests.scala
+++ b/migrations/slick/src/test/scala/SubProjectsTests/MigrationDatabaseTests.scala
@@ -22,9 +22,9 @@ class MigrationDatabaseTest extends FlatSpec
     dir.setup()
     rm(objDir)
     implicit val wd = dir.path
-    %%git 'init
-    %%git('config, "user.email", "test@test.com")
-    %%git('config, "user.name", "Testser")
+    %%git Symbol("init")
+    %%git(Symbol("config"), "user.email", "test@test.com")
+    %%git(Symbol("config"), "user.name", "Testser")
     for (file <- filesToWrite) {
       write(file, "dummy file")
     }

--- a/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
+++ b/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
@@ -79,7 +79,7 @@ trait SQLiteConfigFile extends ConfigFile with Tables {
 trait MySQLConfigFile extends ConfigFile with Tables {
   val user = "root"
   val driver = "slick.jdbc.MySQLProfile$"
-  val dbDriver = "com.mysql.cj.jdbc.Driver"
+  val dbDriver = "com.mysql.jdbc.Driver"
   val dbUrl = s"jdbc:mysql://localhost/circle_test?useSSL=false"
 
   val profile = slick.jdbc.MySQLProfile

--- a/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
+++ b/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
@@ -33,7 +33,7 @@ trait ConfigFile {
 
   protected def migrationsMap = {
     val tmpDir = tmp.dir()
-    val handled = tmpDir/Symbol("main/scala")
+    val handled = tmpDir/Symbol("main")/Symbol("scala")
     mkdir! handled
     val migrationsMap = new HashMap[String, Object]
     migrationsMap.put("slick", slickMap)

--- a/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
+++ b/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
@@ -79,7 +79,7 @@ trait SQLiteConfigFile extends ConfigFile with Tables {
 trait MySQLConfigFile extends ConfigFile with Tables {
   val user = "root"
   val driver = "slick.jdbc.MySQLProfile$"
-  val dbDriver = "com.mysql.jdbc.Driver"
+  val dbDriver = "com.mysql.cj.jdbc.Driver"
   val dbUrl = s"jdbc:mysql://localhost/circle_test?useSSL=false"
 
   val profile = slick.jdbc.MySQLProfile

--- a/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
+++ b/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
@@ -10,7 +10,7 @@ import slick.jdbc.JdbcProfile
 trait ConfigFile {
   this: Tables =>
   val path = System.getProperty("user.dir")
-  val timeout = new Integer(5000)
+  val timeout = Integer.valueOf(5000)
   val driver: String
   val dbDriver: String
   val dbUrl: String
@@ -118,7 +118,7 @@ trait DerbyConfigFile extends ConfigFile with Tables {
   val driver = "slick.jdbc.DerbyProfile$"
   val dbDriver = "org.apache.derby.jdbc.EmbeddedDriver"
   val dbUrl = s"jdbc:derby:$path/target/test-${Instant.now.toEpochMilli}.derby.db;create=true"
-  override val timeout = new Integer(10000)
+  override val timeout = Integer.valueOf(10000)
 
   val profile = slick.jdbc.DerbyProfile
 }

--- a/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
+++ b/migrations/slick/src/test/scala/UnitTests/ConfigFile.scala
@@ -33,7 +33,7 @@ trait ConfigFile {
 
   protected def migrationsMap = {
     val tmpDir = tmp.dir()
-    val handled = tmpDir/'main/'scala
+    val handled = tmpDir/Symbol("main/scala")
     mkdir! handled
     val migrationsMap = new HashMap[String, Object]
     migrationsMap.put("slick", slickMap)

--- a/migrations/slick/src/test/scala/UnitTests/SlickMigrationManagerTests.scala
+++ b/migrations/slick/src/test/scala/UnitTests/SlickMigrationManagerTests.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import slick.jdbc.meta.MTable
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 
 trait MigrationTests extends FlatSpec with PrivateMethodTester {
   this: ConfigFile with Tables =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.10.3

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.3.2"
+ThisBuild / version := "0.3.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2"
+ThisBuild / version := "0.3.2"


### PR DESCRIPTION
The last version of scala-forklift uses slick-migration-api version 0.7.0, which is no longer available in the maven repository. This updates the version to slick-migration-api version 0.10.0 along with updating slick to 3.5.2.

This compiles correctly, the MySQL tests are having a hard time, also on the default code as it currently works. I am therefore going to attempt to create a snapshot release and see if the code changes I have made work.